### PR TITLE
Update swagger.yaml

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -207,7 +207,7 @@ paths:
         - Recurring Consents
       summary: Cria um consentimento para transações de pagamentos.
       operationId: automaticPaymentsPostRecurringConsents
-      description: Método para criação de consentimento de longa duração. Retorna um `recurringConsentId` no status AWAITING_AUTHORISATION.
+      description: Método para criação de consentimento de longa duração. Retorna um `recurringConsentId` no status AWAITING_AUTHORISATION.d asdasdasdasdsadsa
       parameters:
         - $ref: '#/components/parameters/Authorization'
         - $ref: '#/components/parameters/xCustomerUserAgent'


### PR DESCRIPTION
###Contexto
Foi apresentando por uma cadeira uma questão relativa a incerteza da criação de recursos quando um erro HTTP 5XX ocorre durante sua operação. Para permitir uma maior segurança para os envolvidos, essa proposta visa permitir a consulta de recursos, criados ou não, quando um erro desse tipo ocorrer.

###Descrição
Adicionar um novo endpoint à API:
GET /consents/{consentId}/payments